### PR TITLE
Add share button color

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -125,6 +125,21 @@
     background-color: #202020;
   }
 
+  .ui-share-menu .ui-share-copy,
+  .ui-share-menu .ui-share-preview {
+    border-color: #6d6d6d !important;
+    background-color: #333 !important;
+    color: #FFF !important;
+  }
+
+  .ui-share-menu .ui-share-copy:hover,
+  .ui-share-menu .ui-share-copy:focus,
+  .ui-share-menu .ui-share-preview:hover,
+  .ui-share-menu .ui-share-preview:focus {
+    background-color: #737373 !important;
+    color: #FFF !important;
+  }
+  
   .navbar .announcement-popover {
     background: #4F4F4F;
   }


### PR DESCRIPTION
加上分享選單中 `複製` 和 `預覽` 兩個按鈕的顏色

* 修改前

![圖片](https://user-images.githubusercontent.com/7872696/59371513-ca874c80-8d77-11e9-9566-110a721e30cd.png)

* 修改後

![圖片](https://user-images.githubusercontent.com/7872696/59371537-e1c63a00-8d77-11e9-9f82-1782877181d1.png)
